### PR TITLE
Allows Addon devs when doing their compatiblity to set .setstatsAdded…

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/config/compatible_items/ConfigItem.java
+++ b/src/main/java/com/robertx22/mine_and_slash/config/compatible_items/ConfigItem.java
@@ -156,6 +156,16 @@ public class ConfigItem implements IWeighted, ISlashRegistryEntry {
         this.maxRarity = rar;
         return this;
     }
+	
+	public ConfigItem setstatsAddedOnlyOnDrop(boolean bool) {
+		this.statsAddedOnlyOnDrop = bool;
+		return this;
+	}
+	
+	public ConfigItem setdropsAsLoot(boolean bool) {
+		this.dropsAsLoot = bool;
+		return this;
+	}
 
     public boolean isValid() throws Exception {
 


### PR DESCRIPTION
Yes this is AzureDoom, was having issues forking on my main fork so I just reforked with my Organization account.  
Allows Addon devs when doing their compatiblity to set .setstatsAddedOnlyOnDrop(true/false) and .setdropsAsLoot(true/false) so they can override the config.

This is useful for balancing things from an Addon Devs side of things. Doesn't require anything anything special anywhere else so it's just a useful change that doesn't hurt the rest of the mod. 